### PR TITLE
Mirror empy fix upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 RUN pip3 install --upgrade pip && \
-    pip3 install empy \
+    pip3 install empy==3.3.4 \
     future \
     jinja2 \
     kconfiglib \


### PR DESCRIPTION
I was running into problems running the docker container:

```
5.778 Scanning dependencies of target parameters_xml
5.791 [  0%] Generating git version header
5.792 [  0%] Generating combined event json file
5.793 [  0%] Generating serial_params.c
5.796 [  0%] git submodule Tools/sitl_gazebo
5.847 [  0%] Generating px4 event header file
5.850 [  0%] Built target git_gazebo
5.867 Scanning dependencies of target uorb_headers
5.881 [  0%] Generating uORB topic headers
5.918 Traceback (most recent call last):
5.918   File "tools/px_generate_uorb_topic_files.py", line 544, in <module>
5.918     generate_output_from_file(
5.918   File "tools/px_generate_uorb_topic_files.py", line 184, in generate_output_from_file
5.918     return generate_by_template(output_file, template_file, em_globals)
5.918   File "tools/px_generate_uorb_topic_files.py", line 354, in generate_by_template
5.918     em.RAW_OPT: True, em.BUFFERED_OPT: True})
5.918 AttributeError: module 'em' has no attribute 'RAW_OPT'
5.922 make[4]: *** [msg/CMakeFiles/uorb_headers.dir/build.make:414: uORB/topics/uORBTopics.hpp] Error 1
5.922 make[3]: *** [CMakeFiles/Makefile2:6818: msg/CMakeFiles/uorb_headers.dir/all] Error 2
5.922 make[3]: *** Waiting for unfinished jobs....
5.941 [  0%] Built target events_header
6.267 [  0%] Generating parameters.xml
7.468 [  0%] Built target parameters_xml
8.026 [  0%] Built target ver_gen
8.030 make[2]: *** [CMakeFiles/Makefile2:41341: platforms/posix/CMakeFiles/gazebo.dir/rule] Error 2
8.031 make[1]: *** [Makefile:15279: gazebo] Error 2
8.035 make: *** [Makefile:235: px4_sitl] Error 2
------
failed to solve: process "/bin/bash -c      cd ${FIRMWARE_DIR} &&     DONT_RUN=1 make px4_sitl gazebo &&     DONT_RUN=1 make px4_sitl gazebo     " did not complete successfully: exit code: 2
```

I went upstream and found this:

https://github.com/JonasVautherin/px4-gazebo-headless/commit/079dc852fab4d57b98d4d9e5bb546cb12b71cbb6

tried making that same change in my fork, and managed to get the takeoff example running... nice.